### PR TITLE
Filter log messages

### DIFF
--- a/library/src/main/java/io/github/wax911/library/annotation/processor/GraphProcessor.kt
+++ b/library/src/main/java/io/github/wax911/library/annotation/processor/GraphProcessor.kt
@@ -1,10 +1,10 @@
 package io.github.wax911.library.annotation.processor
 
 import android.content.res.AssetManager
-import android.util.Log
 import io.github.wax911.library.annotation.GraphQuery
 import io.github.wax911.library.annotation.processor.fragment.FragmentPatcher
 import io.github.wax911.library.annotation.processor.fragment.GraphRegexUtil
+import io.github.wax911.library.util.Logger
 import java.io.BufferedReader
 import java.io.IOException
 import java.io.InputStream
@@ -31,14 +31,14 @@ class GraphProcessor private constructor(
 
     init {
         synchronized(lock) {
-            Log.d("GraphProcessor", Thread.currentThread().name + ": has obtained a synchronized lock on the object")
+            Logger.d("GraphProcessor", Thread.currentThread().name + ": has obtained a synchronized lock on the object")
             if (_graphFiles.isEmpty()) {
-                Log.d("GraphProcessor", Thread.currentThread().name + ": is initializing query files")
+                Logger.d("GraphProcessor", Thread.currentThread().name + ": is initializing query files")
                 createGraphQLMap(defaultDirectory, assetManager)
-                Log.d("GraphProcessor", Thread.currentThread().name + ": has completed initializing all files")
-                Log.d("GraphProcessor", Thread.currentThread().name + ": Total count of graphFiles -> size: " + _graphFiles.size)
+                Logger.d("GraphProcessor", Thread.currentThread().name + ": has completed initializing all files")
+                Logger.d("GraphProcessor", Thread.currentThread().name + ": Total count of graphFiles -> size: " + _graphFiles.size)
             } else
-                Log.d("GraphProcessor", Thread.currentThread().name + ": skipped initialization of graphFiles -> size: " + _graphFiles.size)
+                Logger.d("GraphProcessor", Thread.currentThread().name + ": skipped initialization of graphFiles -> size: " + _graphFiles.size)
         }
     }
 
@@ -54,11 +54,11 @@ class GraphProcessor private constructor(
 
         if (graphQuery != null) {
             val fileName = String.format("%s%s", graphQuery.value, defaultExtension)
-            Log.d("GraphProcessor", fileName)
+            Logger.d("GraphProcessor", fileName)
             if (_graphFiles.containsKey(fileName))
                 return _graphFiles[fileName]
-            Log.e(this.toString(), String.format("The request query %s could not be found!", graphQuery.value))
-            Log.e(this.toString(), String.format("Current size of graphFiles -> size: %d", _graphFiles.size))
+            Logger.e(this.toString(), String.format("The request query %s could not be found!", graphQuery.value))
+            Logger.e(this.toString(), String.format("Current size of graphFiles -> size: %d", _graphFiles.size))
         }
         return null
     }

--- a/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/FragmentPatcher.kt
+++ b/library/src/main/java/io/github/wax911/library/annotation/processor/fragment/FragmentPatcher.kt
@@ -1,6 +1,6 @@
 package io.github.wax911.library.annotation.processor.fragment
 
-import android.util.Log
+import io.github.wax911.library.util.Logger
 
 /**
  * This class will return a String containing fragment definitions. This String can then be appended to a GraphQL
@@ -32,7 +32,7 @@ class FragmentPatcher(
         // There is at least one missing fragment definition. It may be defined in its own file though. We will do
         // our best to find and include it.
         val count = missingFragments.count()
-        Log.d(TAG, "$count missing fragments in $graphFile. Attempting to find them elsewhere.")
+        Logger.d(TAG, "$count missing fragments in $graphFile. Attempting to find them elsewhere.")
 
         missingFragments.forEach { missingFragment ->
             val includeFile = "${missingFragment.fragmentReference}$defaultExtension"
@@ -49,11 +49,11 @@ class FragmentPatcher(
                 }
             } else {
                 // This fragment is nowhere to be found.
-                Log.e(TAG, "$graphFile references $missingFragment, but it could not be located.")
+                Logger.e(TAG, "$graphFile references $missingFragment, but it could not be located.")
             }
         }
 
-        Log.d(TAG, "Patch produced for: $graphFile\n$aggregation")
+        Logger.d(TAG, "Patch produced for: $graphFile\n$aggregation")
 
         return aggregation.toString()
     }

--- a/library/src/main/java/io/github/wax911/library/converter/GraphConverter.kt
+++ b/library/src/main/java/io/github/wax911/library/converter/GraphConverter.kt
@@ -7,6 +7,8 @@ import io.github.wax911.library.annotation.processor.GraphProcessor
 import io.github.wax911.library.converter.request.GraphRequestConverter
 import io.github.wax911.library.converter.response.GraphResponseConverter
 import io.github.wax911.library.model.request.QueryContainerBuilder
+import io.github.wax911.library.util.LogLevel
+import io.github.wax911.library.util.Logger
 import okhttp3.RequestBody
 import okhttp3.ResponseBody
 import retrofit2.Converter
@@ -73,6 +75,17 @@ open class GraphConverter protected constructor(context: Context?) : Converter.F
         return GraphRequestConverter(methodAnnotations, graphProcessor, gson)
     }
 
+    /**
+     * Sets the minimum level for log messages. Attempted messages with a too low
+     * log level are skipped and not printed to the system log.
+     * <br></br>
+     *
+     *
+     * @param logLevel The minimum log level used to print log messages
+     */
+    fun setLogLevel(logLevel: LogLevel) {
+        Logger.level = logLevel
+    }
 
     companion object {
 

--- a/library/src/main/java/io/github/wax911/library/converter/request/GraphRequestConverter.kt
+++ b/library/src/main/java/io/github/wax911/library/converter/request/GraphRequestConverter.kt
@@ -1,10 +1,10 @@
 package io.github.wax911.library.converter.request
 
-import android.util.Log
 import com.google.gson.Gson
 import io.github.wax911.library.annotation.processor.GraphProcessor
 import io.github.wax911.library.converter.GraphConverter
 import io.github.wax911.library.model.request.QueryContainerBuilder
+import io.github.wax911.library.util.Logger
 import okhttp3.MediaType
 import okhttp3.RequestBody
 import retrofit2.Converter
@@ -31,7 +31,7 @@ open class GraphRequestConverter(
                 .setQuery(graphProcessor.getQuery(methodAnnotations))
                 .build()
         val queryJson = gson.toJson(queryContainer)
-        Log.d("GraphRequestConverter", queryJson)
+        Logger.d("GraphRequestConverter", queryJson)
         return RequestBody.create(MediaType.parse(GraphConverter.MimeType), queryJson)
     }
 }

--- a/library/src/main/java/io/github/wax911/library/persistedquery/PersistedQueryHashCalculator.kt
+++ b/library/src/main/java/io/github/wax911/library/persistedquery/PersistedQueryHashCalculator.kt
@@ -1,8 +1,8 @@
 package io.github.wax911.library.persistedquery
 
 import android.content.Context
-import android.util.Log
 import io.github.wax911.library.annotation.processor.GraphProcessor
+import io.github.wax911.library.util.Logger
 import java.math.BigInteger
 import java.security.MessageDigest
 import java.util.*
@@ -32,15 +32,15 @@ class PersistedQueryHashCalculator constructor(context: Context?) {
     }
 
     private fun createAndStoreHash(queryName: String, fileKey: String): String? {
-        Log.d(this.toString(), "Creating hash for $queryName")
+        Logger.d(this.toString(), "Creating hash for $queryName")
         return if (graphProcessor.graphFiles.containsKey(fileKey)) {
             val hashOfQuery = hashOfQuery(graphProcessor.graphFiles.getValue(fileKey))
-            Log.d(this.toString(), "Created ")
+            Logger.d(this.toString(), "Created ")
             apqHashes[fileKey] = hashOfQuery
             hashOfQuery
         } else {
-            Log.e(this.toString(), "The request query $fileKey could not be found!")
-            Log.e(this.toString(), "Current size of graphFiles -> size: ${graphProcessor.graphFiles.size}")
+            Logger.e(this.toString(), "The request query $fileKey could not be found!")
+            Logger.e(this.toString(), "Current size of graphFiles -> size: ${graphProcessor.graphFiles.size}")
             null
         }
     }

--- a/library/src/main/java/io/github/wax911/library/util/GraphErrorUtil.kt
+++ b/library/src/main/java/io/github/wax911/library/util/GraphErrorUtil.kt
@@ -31,7 +31,7 @@ fun Response<*>?.getError(): List<GraphError>? {
 }
 
 private fun String.getGraphQLError(): List<GraphError>? {
-    Log.e("GraphErrorUtil", this)
+    Logger.e("GraphErrorUtil", this)
     val tokenType = object : TypeToken<GraphContainer<*>>() {}.type
     val graphContainer = Gson().fromJson<GraphContainer<*>>(this, tokenType)
     return graphContainer.errors

--- a/library/src/main/java/io/github/wax911/library/util/Logger.kt
+++ b/library/src/main/java/io/github/wax911/library/util/Logger.kt
@@ -1,0 +1,112 @@
+package io.github.wax911.library.util
+
+import android.util.Log
+
+/**
+ * The levels used to print out and filter log messages
+ *
+ * The order in terms of verbosity, from least to most is
+ * ERROR, WARN, INFO, DEBUG, VERBOSE. Verbose should never be compiled
+ * into an application except during development. Debug logs are compiled
+ * in but stripped at runtime. Error, warning and info logs are always kept.
+ */
+class LogLevel private constructor(private val value: Int) {
+    companion object {
+        /** Priority constant for the println method; use Logger.wtf */
+        val ASSERT = LogLevel(Log.ASSERT)
+
+        /** Priority constant for the println method; use Logger.d */
+        val DEBUG = LogLevel(Log.DEBUG)
+
+        /** Priority constant for the println method; use Logger.e */
+        val ERROR = LogLevel(Log.ERROR)
+
+        /** Priority constant for the println method; use Logger.i */
+        val INFO = LogLevel(Log.INFO)
+
+        /** Priority constant for the println method; use Logger.v */
+        val VERBOSE = LogLevel(Log.VERBOSE)
+
+        /** Priority constant for the println method; use Logger.w */
+        val WARN = LogLevel(Log.WARN)
+    }
+
+    operator fun compareTo(other: LogLevel) = this.value.compareTo(other.value)
+}
+
+internal object Logger {
+
+    var level: LogLevel = LogLevel.VERBOSE
+
+    /**
+     * Send a {@link #DEBUG} log message and log the exception.
+     * @param tag Used to identify the source of a log message. It usually identifies
+     *        the class or activity where the log call occurs.
+     * @param msg The message you would like logged.
+     * @param tr An exception to log
+     */
+    fun d(tag: String, msg: String, tr: Throwable? = null) {
+        if(level < LogLevel.DEBUG) return
+        else Log.d(tag, msg, tr)
+    }
+
+    /**
+     * Send a {@link #ERROR} log message and log the exception.
+     * @param tag Used to identify the source of a log message. It usually identifies
+     *        the class or activity where the log call occurs.
+     * @param msg The message you would like logged.
+     * @param tr An exception to log
+     */
+    fun e(tag: String, msg: String, tr: Throwable? = null) {
+        if(level < LogLevel.ERROR) return
+        else Log.e(tag, msg, tr)
+    }
+
+    /**
+     * Send a {@link #INFO} log message and log the exception.
+     * @param tag Used to identify the source of a log message. It usually identifies
+     *        the class or activity where the log call occurs.
+     * @param msg The message you would like logged.
+     * @param tr An exception to log
+     */
+    fun i(tag: String, msg: String, tr: Throwable? = null) {
+        if(level < LogLevel.INFO) return
+        else Log.i(tag, msg, tr)
+    }
+
+    /**
+     * Send a {@link #VERBOSE} log message and log the exception.
+     * @param tag Used to identify the source of a log message. It usually identifies
+     *        the class or activity where the log call occurs.
+     * @param msg The message you would like logged.
+     * @param tr An exception to log
+     */
+    fun v(tag: String, msg: String, tr: Throwable? = null) {
+        if(level < LogLevel.VERBOSE) return
+        else Log.v(tag, msg, tr)
+    }
+
+    /**
+     * Send a {@link #WARN} log message and log the exception.
+     * @param tag Used to identify the source of a log message. It usually identifies
+     *        the class or activity where the log call occurs.
+     * @param msg The message you would like logged.
+     * @param tr An exception to log
+     */
+    fun w(tag: String, msg: String, tr: Throwable? = null) {
+        if(level < LogLevel.WARN) return
+        else Log.w(tag, msg, tr)
+    }
+
+    /**
+     * What a Terrible Failure: Report an exception that should never happen.
+     * Similar to {@link #wtf(String, Throwable)}, with a message as well.
+     * @param tag Used to identify the source of a log message.
+     * @param msg The message you would like logged.
+     * @param tr An exception to log.  May be null.
+     */
+    fun wtf(tag: String, msg: String, tr: Throwable? = null) {
+        if(level < LogLevel.ASSERT) return
+        else Log.wtf(tag, msg, tr)
+    }
+}


### PR DESCRIPTION
## Description
Added a Logger so that log messages can be filtered now

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context
The FragmentPatcher (and other classes as well) write lots of messages to the system log. When the query become larger this can really mess up the log of a production application. Therefore this pull request introduces a new Logger class which lets the developer adjust the messages which will be written to the log.