### PR TITLE
Add standard extensions Map<String, Object> to GraphError

### DIFF
--- a/library/src/main/java/io/github/wax911/library/model/attribute/GraphError.kt
+++ b/library/src/main/java/io/github/wax911/library/model/attribute/GraphError.kt
@@ -3,7 +3,8 @@ package io.github.wax911.library.model.attribute
 data class GraphError(
         val message: String?,
         val status: Int,
-        val locations: List<Map<String, Int>>?
+        val locations: List<Map<String, Int>>?,
+        val extensions: Map<String, Any>?
 ) {
 
     override fun toString(): String {
@@ -11,6 +12,7 @@ data class GraphError(
                 "message='" + message + '\''.toString() +
                 ", status=" + status +
                 ", locations=" + locations +
+                ", extensions=" + extensions +
                 '}'.toString()
     }
 }


### PR DESCRIPTION
## Description
Standard GraphQL error responses contain a certain amount of keys, most of which are already contained within the library's `GraphError` data class (with the rest laid out in the official [GraphQL documentation](https://spec.graphql.org/June2018/#sec-Errors)). However, one that is missing from this library, is the `extensions` map. This `extensions` map is on almost all backend GraphQL libraries. To name a few:
- [graphql-js](https://github.com/graphql/graphql-js/blob/278bde0a5cd71008452b555065f19dcd1160270a/src/error/GraphQLError.js#L77)
- [graphql-java](https://github.com/graphql-java/graphql-java/blob/9eae9c1bf506700cd0a54bf37364e28e2519a2f4/src/main/java/graphql/GraphQLError.java#L65)
- [graphql-python](https://github.com/graphql-python/graphql-core/blob/5951f1a242775116b6fd9767308790b432d1f756/src/graphql/error/graphql_error.py#L67)


## Motivation and Context
Adding this field gives flexibility to backend implementors, allowing the client to parse dynamic error responses and being able to add additional error cases over time. Also, this library is awesome and hope to never stop using it 😄 !

## How Has This Been Tested?
Compiled this library and was able to parse an error response with a custom extensions map! 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!--- Be kind to code reviewers, please try to keep pull requests as small and focused as possible :) -->

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [Apache License](https://github.com/AniTrend/retrofit-graphql/blob/master/LICENSE.md).
