### PR TITLE
chore(spotless): consolidate spotless config into buildSrc helper for JVM modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -248,3 +248,6 @@ app/lint-baseline.xml
 # Added by code-review-graph
 .code-review-graph/
 .claude/
+
+# OpenCode deepwork session files
+.slim/deepwork/

--- a/annotations/build.gradle.kts
+++ b/annotations/build.gradle.kts
@@ -1,3 +1,8 @@
+import co.anitrend.retrofit.graphql.buildSrc.plugin.components.configureSpotlessForJvm
+
 plugins {
     kotlin("jvm")
 }
+
+configureSpotlessForJvm()
+

--- a/buildSrc/src/main/java/co/anitrend/retrofit/graphql/buildSrc/plugin/components/JvmConfiguration.kt
+++ b/buildSrc/src/main/java/co/anitrend/retrofit/graphql/buildSrc/plugin/components/JvmConfiguration.kt
@@ -1,0 +1,23 @@
+package co.anitrend.retrofit.graphql.buildSrc.plugin.components
+
+import co.anitrend.retrofit.graphql.buildSrc.plugin.extensions.libs
+import com.diffplug.gradle.spotless.SpotlessExtension
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+fun Project.configureSpotlessForJvm() {
+    plugins.apply("com.diffplug.spotless")
+    configure<SpotlessExtension> {
+        kotlin {
+            target("**/*.kt")
+            targetExclude(
+                "${layout.buildDirectory.get()}/**/*.kt",
+                "**/test/**/*.kt",
+                "bin/**/*.kt"
+            )
+            ktlint(libs.pintrest.ktlint.get().version)
+                .editorConfigOverride(mapOf("ktlint_standard_filename" to "disabled"))
+            licenseHeaderFile(rootProject.file("spotless/copyright.kt"))
+        }
+    }
+}

--- a/codegen-core/build.gradle.kts
+++ b/codegen-core/build.gradle.kts
@@ -1,6 +1,10 @@
+import co.anitrend.retrofit.graphql.buildSrc.plugin.components.configureSpotlessForJvm
+
 plugins {
     kotlin("jvm")
 }
+
+configureSpotlessForJvm()
 
 dependencies {
     implementation(libs.graphql.java)
@@ -8,3 +12,4 @@ dependencies {
 
     testImplementation(libs.junit)
 }
+

--- a/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/generate/DocumentGenerator.kt
+++ b/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/generate/DocumentGenerator.kt
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 AniTrend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package co.anitrend.retrofit.graphql.codegen.generate
 
 import co.anitrend.retrofit.graphql.codegen.model.GraphQLOperationInfo
@@ -25,7 +41,6 @@ import com.squareup.kotlinpoet.TypeSpec
  * ```
  */
 object DocumentGenerator {
-
     fun generate(
         operations: List<GraphQLOperationInfo>,
         packageName: String,
@@ -40,11 +55,11 @@ object DocumentGenerator {
                                 PropertySpec.builder(op.name, String::class)
                                     .addModifiers(KModifier.PUBLIC, KModifier.CONST)
                                     .initializer("%S", op.document)
-                                    .build()
+                                    .build(),
                             )
                         }
                     }
-                    .build()
+                    .build(),
             )
             .build()
     }

--- a/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/generate/EnumGenerator.kt
+++ b/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/generate/EnumGenerator.kt
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 AniTrend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package co.anitrend.retrofit.graphql.codegen.generate
 
 import co.anitrend.retrofit.graphql.codegen.model.SchemaType
@@ -22,7 +38,6 @@ import com.squareup.kotlinpoet.TypeSpec
  * Future: Optional Kotlin enum class generation via [EnumGenerator.generateAsEnumClass].
  */
 object EnumGenerator {
-
     /**
      * Generates string constants for a list of enum types.
      * All enums are grouped into a single `GraphQLEnums` file.
@@ -33,14 +48,15 @@ object EnumGenerator {
     ): FileSpec? {
         if (enums.isEmpty()) return null
 
-        val outerSpec = TypeSpec.objectBuilder("GraphQLEnums")
-            .addModifiers(KModifier.PUBLIC)
-            .apply {
-                enums.forEach { enumType ->
-                    addType(buildEnumObject(enumType))
+        val outerSpec =
+            TypeSpec.objectBuilder("GraphQLEnums")
+                .addModifiers(KModifier.PUBLIC)
+                .apply {
+                    enums.forEach { enumType ->
+                        addType(buildEnumObject(enumType))
+                    }
                 }
-            }
-            .build()
+                .build()
 
         return FileSpec.builder(packageName, "GraphQLEnums")
             .addType(outerSpec)
@@ -54,14 +70,15 @@ object EnumGenerator {
         enumType: SchemaType.Enum,
         packageName: String,
     ): FileSpec {
-        val typeSpec = TypeSpec.enumBuilder(enumType.name)
-            .addModifiers(KModifier.PUBLIC)
-            .apply {
-                enumType.values.forEach { value ->
-                    addEnumConstant(value)
+        val typeSpec =
+            TypeSpec.enumBuilder(enumType.name)
+                .addModifiers(KModifier.PUBLIC)
+                .apply {
+                    enumType.values.forEach { value ->
+                        addEnumConstant(value)
+                    }
                 }
-            }
-            .build()
+                .build()
 
         return FileSpec.builder(packageName, enumType.name)
             .addType(typeSpec)
@@ -77,7 +94,7 @@ object EnumGenerator {
                         PropertySpec.builder(value, String::class)
                             .addModifiers(KModifier.PUBLIC, KModifier.CONST)
                             .initializer("%S", value)
-                            .build()
+                            .build(),
                     )
                 }
             }

--- a/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/generate/HashConstantsGenerator.kt
+++ b/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/generate/HashConstantsGenerator.kt
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 AniTrend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package co.anitrend.retrofit.graphql.codegen.generate
 
 import co.anitrend.retrofit.graphql.codegen.hash.APQHashGenerator
@@ -20,7 +36,6 @@ import com.squareup.kotlinpoet.TypeSpec
  * ```
  */
 object HashConstantsGenerator {
-
     fun generate(
         operations: List<GraphQLOperationInfo>,
         packageName: String,
@@ -36,11 +51,11 @@ object HashConstantsGenerator {
                                 PropertySpec.builder(op.name, String::class)
                                     .addModifiers(KModifier.PUBLIC, KModifier.CONST)
                                     .initializer("%S", hash)
-                                    .build()
+                                    .build(),
                             )
                         }
                     }
-                    .build()
+                    .build(),
             )
             .build()
     }

--- a/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/generate/InputObjectGenerator.kt
+++ b/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/generate/InputObjectGenerator.kt
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 AniTrend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package co.anitrend.retrofit.graphql.codegen.generate
 
 import co.anitrend.retrofit.graphql.codegen.mapping.GraphQLTypeMapper
@@ -22,7 +38,6 @@ import com.squareup.kotlinpoet.TypeSpec
  * ```
  */
 object InputObjectGenerator {
-
     private val VARIABLES_INTERFACE = ClassName("co.anitrend.retrofit.graphql.model", "GraphQLVariables")
 
     /**
@@ -45,39 +60,41 @@ object InputObjectGenerator {
         scalarMappings: Map<String, String>,
         schemaTypeNames: Set<String>,
     ): FileSpec {
-        val typeSpec = TypeSpec.classBuilder(inputObject.name)
-            .addModifiers(KModifier.PUBLIC, KModifier.DATA)
-            .addSuperinterface(VARIABLES_INTERFACE)
-            .apply {
-                val params = inputObject.fields.map { field ->
-                    val kotlinType = parseKotlinTypeString(field.type, scalarMappings, schemaTypeNames)
-                    val paramBuilder = ParameterSpec.builder(field.name, kotlinType)
-                    if (field.defaultValue != null) {
-                        paramBuilder.defaultValue(
-                            convertGraphQLDefaultToKotlin(field.defaultValue, field.type)
+        val typeSpec =
+            TypeSpec.classBuilder(inputObject.name)
+                .addModifiers(KModifier.PUBLIC, KModifier.DATA)
+                .addSuperinterface(VARIABLES_INTERFACE)
+                .apply {
+                    val params =
+                        inputObject.fields.map { field ->
+                            val kotlinType = parseKotlinTypeString(field.type, scalarMappings, schemaTypeNames)
+                            val paramBuilder = ParameterSpec.builder(field.name, kotlinType)
+                            if (field.defaultValue != null) {
+                                paramBuilder.defaultValue(
+                                    convertGraphQLDefaultToKotlin(field.defaultValue, field.type),
+                                )
+                            }
+                            paramBuilder.build()
+                        }
+                    primaryConstructor(
+                        com.squareup.kotlinpoet.FunSpec.constructorBuilder()
+                            .addParameters(params)
+                            .build(),
+                    )
+                    // Properties
+                    inputObject.fields.forEach { field ->
+                        addProperty(
+                            PropertySpec.builder(
+                                field.name,
+                                parseKotlinTypeString(field.type, scalarMappings, schemaTypeNames),
+                            )
+                                .initializer(field.name)
+                                .addModifiers(KModifier.PUBLIC)
+                                .build(),
                         )
                     }
-                    paramBuilder.build()
                 }
-                primaryConstructor(
-                    com.squareup.kotlinpoet.FunSpec.constructorBuilder()
-                        .addParameters(params)
-                        .build()
-                )
-                // Properties
-                inputObject.fields.forEach { field ->
-                    addProperty(
-                        PropertySpec.builder(
-                            field.name,
-                            parseKotlinTypeString(field.type, scalarMappings, schemaTypeNames)
-                        )
-                            .initializer(field.name)
-                            .addModifiers(KModifier.PUBLIC)
-                            .build()
-                    )
-                }
-            }
-            .build()
+                .build()
 
         return FileSpec.builder(packageName, inputObject.name)
             .addType(typeSpec)
@@ -92,7 +109,10 @@ object InputObjectGenerator {
         return GraphQLTypeMapper.toKotlinType(type, scalarMappings, schemaTypeNames)
     }
 
-    private fun convertGraphQLDefaultToKotlin(defaultValue: String, type: GraphQLType): String {
+    private fun convertGraphQLDefaultToKotlin(
+        defaultValue: String,
+        type: GraphQLType,
+    ): String {
         return when {
             defaultValue == "null" -> "null"
             defaultValue.startsWith("\"") -> defaultValue

--- a/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/generate/OperationConstantsGenerator.kt
+++ b/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/generate/OperationConstantsGenerator.kt
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 AniTrend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package co.anitrend.retrofit.graphql.codegen.generate
 
 import co.anitrend.retrofit.graphql.codegen.model.GraphQLOperationInfo
@@ -24,7 +40,6 @@ import com.squareup.kotlinpoet.TypeSpec
  * ```
  */
 object OperationConstantsGenerator {
-
     fun generate(
         operations: List<GraphQLOperationInfo>,
         packageName: String,
@@ -38,7 +53,7 @@ object OperationConstantsGenerator {
                     .addType(buildOperationGroup(OperationType.QUERY, grouped))
                     .addType(buildOperationGroup(OperationType.MUTATION, grouped))
                     .addType(buildOperationGroup(OperationType.SUBSCRIPTION, grouped))
-                    .build()
+                    .build(),
             )
             .build()
     }
@@ -58,7 +73,7 @@ object OperationConstantsGenerator {
                         PropertySpec.builder(op.name, String::class)
                             .addModifiers(KModifier.PUBLIC, KModifier.CONST)
                             .initializer("%S", op.name)
-                            .build()
+                            .build(),
                     )
                 }
             }

--- a/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/generate/OperationRequestGenerator.kt
+++ b/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/generate/OperationRequestGenerator.kt
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 AniTrend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package co.anitrend.retrofit.graphql.codegen.generate
 
 import co.anitrend.retrofit.graphql.codegen.mapping.GraphQLTypeMapper
@@ -36,7 +52,6 @@ import com.squareup.kotlinpoet.TypeSpec
  * ```
  */
 object OperationRequestGenerator {
-
     private val GRAPHQL_OPERATION = ClassName("co.anitrend.retrofit.graphql.model", "GraphQLOperation")
     private val GRAPHQL_NO_VAR_OPERATION = ClassName("co.anitrend.retrofit.graphql.model", "GraphQLNoVarOperation")
     private val GRAPHQL_REQUEST = ClassName("co.anitrend.retrofit.graphql.model", "GraphQLRequest")
@@ -57,24 +72,26 @@ object OperationRequestGenerator {
         val variablesClassName = "${operation.name}Variables"
         val variablesClass = ClassName("", variablesClassName)
 
-        val superInterface = if (hasVariables) {
-            GRAPHQL_OPERATION.parameterizedBy(variablesClass)
-        } else {
-            GRAPHQL_NO_VAR_OPERATION
-        }
-
-        val typeSpec = TypeSpec.objectBuilder(operation.name)
-            .addModifiers(KModifier.PUBLIC)
-            .addSuperinterface(superInterface)
-            .addProperty(nameProperty(operation))
-            .addProperty(documentProperty(operation))
-            .addProperty(sha256HashProperty(operation))
-            .apply {
-                if (hasVariables) {
-                    addFunction(buildRequestFunction(operation, variablesClass, scalarMappings, schemaTypeNames))
-                }
+        val superInterface =
+            if (hasVariables) {
+                GRAPHQL_OPERATION.parameterizedBy(variablesClass)
+            } else {
+                GRAPHQL_NO_VAR_OPERATION
             }
-            .build()
+
+        val typeSpec =
+            TypeSpec.objectBuilder(operation.name)
+                .addModifiers(KModifier.PUBLIC)
+                .addSuperinterface(superInterface)
+                .addProperty(nameProperty(operation))
+                .addProperty(documentProperty(operation))
+                .addProperty(sha256HashProperty(operation))
+                .apply {
+                    if (hasVariables) {
+                        addFunction(buildRequestFunction(operation, variablesClass, scalarMappings, schemaTypeNames))
+                    }
+                }
+                .build()
 
         return FileSpec.builder(packageName, operation.name)
             .addType(typeSpec)
@@ -110,16 +127,17 @@ object OperationRequestGenerator {
         scalarMappings: Map<String, String>,
         schemaTypeNames: Set<String>,
     ): FunSpec {
-        val params = operation.variables.map { variable ->
-            val kotlinType = parseKotlinTypeString(variable.type, scalarMappings, schemaTypeNames)
-            val paramBuilder = ParameterSpec.builder(variable.name, kotlinType)
-            if (variable.defaultValue != null) {
-                paramBuilder.defaultValue(
-                    convertGraphQLDefaultToKotlin(variable.defaultValue, variable.type)
-                )
+        val params =
+            operation.variables.map { variable ->
+                val kotlinType = parseKotlinTypeString(variable.type, scalarMappings, schemaTypeNames)
+                val paramBuilder = ParameterSpec.builder(variable.name, kotlinType)
+                if (variable.defaultValue != null) {
+                    paramBuilder.defaultValue(
+                        convertGraphQLDefaultToKotlin(variable.defaultValue, variable.type),
+                    )
+                }
+                paramBuilder.build()
             }
-            paramBuilder.build()
-        }
 
         // Build the variables constructor call: GetMarketPlaceAppsVariables(after = after, ...)
         val varArgs = operation.variables.joinToString(", ") { "${it.name} = ${it.name}" }
@@ -145,7 +163,10 @@ object OperationRequestGenerator {
         return GraphQLTypeMapper.toKotlinType(type, scalarMappings, schemaTypeNames)
     }
 
-    private fun convertGraphQLDefaultToKotlin(defaultValue: String, type: GraphQLType): String {
+    private fun convertGraphQLDefaultToKotlin(
+        defaultValue: String,
+        type: GraphQLType,
+    ): String {
         return when {
             defaultValue == "null" -> "null"
             defaultValue.startsWith("\"") -> defaultValue

--- a/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/generate/RegistryGenerator.kt
+++ b/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/generate/RegistryGenerator.kt
@@ -1,12 +1,26 @@
+/**
+ * Copyright 2026 AniTrend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package co.anitrend.retrofit.graphql.codegen.generate
 
-import co.anitrend.retrofit.graphql.codegen.hash.APQHashGenerator
 import co.anitrend.retrofit.graphql.codegen.model.GraphQLOperationInfo
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
-import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.TypeSpec
 
 /**
@@ -33,11 +47,11 @@ import com.squareup.kotlinpoet.TypeSpec
  * ```
  */
 object RegistryGenerator {
-
-    private val REGISTRY_INTERFACE = ClassName(
-        "co.anitrend.retrofit.graphql.model",
-        "GraphQLDocumentRegistry"
-    )
+    private val REGISTRY_INTERFACE =
+        ClassName(
+            "co.anitrend.retrofit.graphql.model",
+            "GraphQLDocumentRegistry",
+        )
     private val OPERATIONS_CLASS = ClassName("", "GraphQLOperations")
     private val DOCUMENTS_CLASS = ClassName("", "GraphQLDocuments")
     private val HASHES_CLASS = ClassName("", "GraphQLHashes")
@@ -53,14 +67,12 @@ object RegistryGenerator {
                     .addSuperinterface(REGISTRY_INTERFACE)
                     .addFunction(buildDocumentFunction(operations))
                     .addFunction(buildHashFunction(operations))
-                    .build()
+                    .build(),
             )
             .build()
     }
 
-    private fun buildDocumentFunction(
-        operations: List<GraphQLOperationInfo>,
-    ): FunSpec {
+    private fun buildDocumentFunction(operations: List<GraphQLOperationInfo>): FunSpec {
         return FunSpec.builder("document")
             .addModifiers(KModifier.OVERRIDE, KModifier.PUBLIC)
             .addParameter("operationName", String::class)
@@ -71,7 +83,8 @@ object RegistryGenerator {
                     val constRef = "${op.type.name.lowercase().replaceFirstChar { it.uppercase() }}.${op.name}"
                     addStatement(
                         "%T.$constRef -> %T.${op.name}",
-                        OPERATIONS_CLASS, DOCUMENTS_CLASS
+                        OPERATIONS_CLASS,
+                        DOCUMENTS_CLASS,
                     )
                 }
             }
@@ -80,9 +93,7 @@ object RegistryGenerator {
             .build()
     }
 
-    private fun buildHashFunction(
-        operations: List<GraphQLOperationInfo>,
-    ): FunSpec {
+    private fun buildHashFunction(operations: List<GraphQLOperationInfo>): FunSpec {
         return FunSpec.builder("hash")
             .addModifiers(KModifier.OVERRIDE, KModifier.PUBLIC)
             .addParameter("operationName", String::class)
@@ -93,7 +104,8 @@ object RegistryGenerator {
                     val constRef = "${op.type.name.lowercase().replaceFirstChar { it.uppercase() }}.${op.name}"
                     addStatement(
                         "%T.$constRef -> %T.${op.name}",
-                        OPERATIONS_CLASS, HASHES_CLASS
+                        OPERATIONS_CLASS,
+                        HASHES_CLASS,
                     )
                 }
             }

--- a/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/generate/VariableClassGenerator.kt
+++ b/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/generate/VariableClassGenerator.kt
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 AniTrend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package co.anitrend.retrofit.graphql.codegen.generate
 
 import co.anitrend.retrofit.graphql.codegen.mapping.GraphQLTypeMapper
@@ -24,7 +40,6 @@ import com.squareup.kotlinpoet.TypeSpec
  * ```
  */
 object VariableClassGenerator {
-
     private val VARIABLES_INTERFACE = ClassName("co.anitrend.retrofit.graphql.model", "GraphQLVariables")
 
     /**
@@ -41,33 +56,35 @@ object VariableClassGenerator {
 
         val className = "${operation.name}Variables"
 
-        val typeSpec = TypeSpec.classBuilder(className)
-            .addModifiers(KModifier.PUBLIC, KModifier.DATA)
-            .addSuperinterface(VARIABLES_INTERFACE)
-            .apply {
-                // Constructor parameters
-                val constructorParams = operation.variables.map { variable ->
-                    buildConstructorParam(variable, scalarMappings, schemaTypeNames)
-                }
-                primaryConstructor(
-                    com.squareup.kotlinpoet.FunSpec.constructorBuilder()
-                        .addParameters(constructorParams)
-                        .build()
-                )
-                // Properties
-                operation.variables.forEach { variable ->
-                    addProperty(
-                        PropertySpec.builder(
-                            variable.name,
-                            parseKotlinTypeString(variable.type, scalarMappings, schemaTypeNames)
-                        )
-                            .initializer(variable.name)
-                            .addModifiers(KModifier.PUBLIC)
-                            .build()
+        val typeSpec =
+            TypeSpec.classBuilder(className)
+                .addModifiers(KModifier.PUBLIC, KModifier.DATA)
+                .addSuperinterface(VARIABLES_INTERFACE)
+                .apply {
+                    // Constructor parameters
+                    val constructorParams =
+                        operation.variables.map { variable ->
+                            buildConstructorParam(variable, scalarMappings, schemaTypeNames)
+                        }
+                    primaryConstructor(
+                        com.squareup.kotlinpoet.FunSpec.constructorBuilder()
+                            .addParameters(constructorParams)
+                            .build(),
                     )
+                    // Properties
+                    operation.variables.forEach { variable ->
+                        addProperty(
+                            PropertySpec.builder(
+                                variable.name,
+                                parseKotlinTypeString(variable.type, scalarMappings, schemaTypeNames),
+                            )
+                                .initializer(variable.name)
+                                .addModifiers(KModifier.PUBLIC)
+                                .build(),
+                        )
+                    }
                 }
-            }
-            .build()
+                .build()
 
         return FileSpec.builder(packageName, className)
             .addType(typeSpec)
@@ -102,7 +119,10 @@ object VariableClassGenerator {
     /**
      * Converts a GraphQL default value literal to a Kotlin expression.
      */
-    private fun convertGraphQLDefaultToKotlin(defaultValue: String, type: GraphQLType): String {
+    private fun convertGraphQLDefaultToKotlin(
+        defaultValue: String,
+        type: GraphQLType,
+    ): String {
         return when {
             defaultValue == "null" -> "null"
             defaultValue.startsWith("\"") -> defaultValue // String literal -- keep as-is

--- a/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/hash/APQHashGenerator.kt
+++ b/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/hash/APQHashGenerator.kt
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 AniTrend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package co.anitrend.retrofit.graphql.codegen.hash
 
 import java.security.MessageDigest
@@ -10,7 +26,6 @@ import java.security.MessageDigest
  * sent over the wire (after fragment flattening).
  */
 object APQHashGenerator {
-
     /**
      * Computes the SHA-256 hex digest of the given document text.
      */

--- a/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/mapping/GraphQLTypeMapper.kt
+++ b/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/mapping/GraphQLTypeMapper.kt
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 AniTrend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package co.anitrend.retrofit.graphql.codegen.mapping
 
 import co.anitrend.retrofit.graphql.codegen.model.GraphQLType
@@ -10,18 +26,18 @@ import com.squareup.kotlinpoet.TypeName
  * and knowledge of schema-defined input/enum types.
  */
 object GraphQLTypeMapper {
-
     /**
      * Built-in GraphQL scalar types mapped to their Kotlin equivalents.
      * Maps non-null variants; nullable wrapping is handled by [toKotlinType].
      */
-    private val BUILT_IN_SCALARS = mapOf(
-        "String" to "kotlin.String",
-        "Int" to "kotlin.Int",
-        "Float" to "kotlin.Double",
-        "Boolean" to "kotlin.Boolean",
-        "ID" to "kotlin.String",
-    )
+    private val BUILT_IN_SCALARS =
+        mapOf(
+            "String" to "kotlin.String",
+            "Int" to "kotlin.Int",
+            "Float" to "kotlin.Double",
+            "Boolean" to "kotlin.Boolean",
+            "ID" to "kotlin.String",
+        )
 
     /**
      * Maps a [GraphQLType] to a KotlinPoet [TypeName] suitable for use in code generation.
@@ -44,8 +60,9 @@ object GraphQLTypeMapper {
             }
             is GraphQLType.List -> {
                 val elementType = toKotlinType(type.of, scalarMappings, schemaTypeNames)
-                val listType = ClassName("kotlin.collections", "List")
-                    .parameterizedBy(elementType)
+                val listType =
+                    ClassName("kotlin.collections", "List")
+                        .parameterizedBy(elementType)
                 if (type.nullable) listType.copy(nullable = true) else listType
             }
         }
@@ -72,7 +89,7 @@ object GraphQLTypeMapper {
         error(
             "Unknown scalar type '$name'. " +
                 "Add a scalar mapping in the retrofitGraphQL {} extension, e.g.:\n" +
-                "  scalars { map(\"$name\", \"kotlin.String\") }"
+                "  scalars { map(\"$name\", \"kotlin.String\") }",
         )
     }
 

--- a/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/model/GraphQLFragmentInfo.kt
+++ b/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/model/GraphQLFragmentInfo.kt
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 AniTrend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package co.anitrend.retrofit.graphql.codegen.model
 
 /**

--- a/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/model/GraphQLOperationInfo.kt
+++ b/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/model/GraphQLOperationInfo.kt
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 AniTrend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package co.anitrend.retrofit.graphql.codegen.model
 
 /**

--- a/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/model/GraphQLVariableInfo.kt
+++ b/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/model/GraphQLVariableInfo.kt
@@ -1,10 +1,25 @@
+/**
+ * Copyright 2026 AniTrend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package co.anitrend.retrofit.graphql.codegen.model
 
 /**
  * Represents a parsed GraphQL type reference from a variable or field definition.
  */
 sealed class GraphQLType {
-
     /**
      * A named type reference, e.g. "String", "MyInput", "DateTime".
      * @param nullable Whether the type is nullable (no trailing !).

--- a/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/model/OperationType.kt
+++ b/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/model/OperationType.kt
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 AniTrend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package co.anitrend.retrofit.graphql.codegen.model
 
 /**
@@ -6,14 +22,16 @@ package co.anitrend.retrofit.graphql.codegen.model
 enum class OperationType {
     QUERY,
     MUTATION,
-    SUBSCRIPTION;
+    SUBSCRIPTION,
+    ;
 
     companion object {
-        fun fromGraphQLJava(name: String): OperationType = when (name.lowercase()) {
-            "query" -> QUERY
-            "mutation" -> MUTATION
-            "subscription" -> SUBSCRIPTION
-            else -> throw IllegalArgumentException("Unknown operation type: $name")
-        }
+        fun fromGraphQLJava(name: String): OperationType =
+            when (name.lowercase()) {
+                "query" -> QUERY
+                "mutation" -> MUTATION
+                "subscription" -> SUBSCRIPTION
+                else -> throw IllegalArgumentException("Unknown operation type: $name")
+            }
     }
 }

--- a/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/model/SchemaIR.kt
+++ b/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/model/SchemaIR.kt
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 AniTrend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package co.anitrend.retrofit.graphql.codegen.model
 
 /**

--- a/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/parser/GraphQLDocumentParser.kt
+++ b/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/parser/GraphQLDocumentParser.kt
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 AniTrend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package co.anitrend.retrofit.graphql.codegen.parser
 
 import co.anitrend.retrofit.graphql.codegen.model.GraphQLFragmentInfo
@@ -14,7 +30,6 @@ import java.io.File
  * Parses .graphql files into structured [GraphQLOperationInfo] and [GraphQLFragmentInfo] models.
  */
 class GraphQLDocumentParser {
-
     private val parser = Parser()
     private val schemaTypeParser = SchemaParser()
 
@@ -32,11 +47,12 @@ class GraphQLDocumentParser {
         return document.definitions
             .filterIsInstance<OperationDefinition>()
             .map { definition ->
-                val name = definition.name
-                    ?: throw IllegalArgumentException(
-                        "Anonymous operations are not allowed. " +
-                            "Provide a name for the operation in ${file.name}."
-                    )
+                val name =
+                    definition.name
+                        ?: throw IllegalArgumentException(
+                            "Anonymous operations are not allowed. " +
+                                "Provide a name for the operation in ${file.name}.",
+                        )
                 val type = OperationType.fromGraphQLJava(definition.operation.name)
                 val originalDocument = extractDocumentText(source, definition)
                 val variables = definition.variableDefinitions.map { parseVariable(it) }
@@ -56,10 +72,12 @@ class GraphQLDocumentParser {
      */
     private fun parseVariable(definition: VariableDefinition): GraphQLVariableInfo {
         return GraphQLVariableInfo(
-            name = definition.name
+            name =
+            definition.name
                 ?: throw IllegalArgumentException("Variable definition must have a name"),
             type = schemaTypeParser.toGraphQLType(definition.type),
-            defaultValue = definition.defaultValue?.let {
+            defaultValue =
+            definition.defaultValue?.let {
                 graphql.language.AstPrinter.printAst(it)
             },
         )

--- a/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/parser/SchemaParser.kt
+++ b/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/parser/SchemaParser.kt
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 AniTrend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package co.anitrend.retrofit.graphql.codegen.parser
 
 import co.anitrend.retrofit.graphql.codegen.model.GraphQLType
@@ -18,7 +34,6 @@ import java.io.File
  * input object types, enum types, and scalar type definitions for code generation.
  */
 class SchemaParser {
-
     private val parser = Parser()
 
     /**
@@ -68,8 +83,9 @@ class SchemaParser {
                 GraphQLType.List(of = elementType, nullable = true)
             }
             is TypeName -> {
-                val typeName = type.name
-                    ?: throw IllegalArgumentException("TypeName must have a name")
+                val typeName =
+                    type.name
+                        ?: throw IllegalArgumentException("TypeName must have a name")
                 GraphQLType.Named(name = typeName, nullable = true)
             }
             else -> error("Unsupported type node: ${type.javaClass.simpleName}")
@@ -77,9 +93,10 @@ class SchemaParser {
     }
 
     private fun parseInputObject(definition: InputObjectTypeDefinition): SchemaType.InputObject {
-        val fields = definition.inputValueDefinitions.map { field ->
-            parseInputField(field)
-        }
+        val fields =
+            definition.inputValueDefinitions.map { field ->
+                parseInputField(field)
+            }
         return SchemaType.InputObject(
             name = definition.name,
             fields = fields,

--- a/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/resolve/FragmentResolver.kt
+++ b/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/resolve/FragmentResolver.kt
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 AniTrend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package co.anitrend.retrofit.graphql.codegen.resolve
 
 import co.anitrend.retrofit.graphql.codegen.model.GraphQLFragmentInfo
@@ -24,7 +40,6 @@ import graphql.util.TreeTransformerUtil
  * Cyclic fragment references are detected and rejected before transformation.
  */
 class FragmentResolver {
-
     private val parser = Parser()
 
     /**
@@ -41,12 +56,13 @@ class FragmentResolver {
         if (fragments.isEmpty()) return operations
 
         // Pre-parse all fragment definitions into FragmentDefinition AST nodes
-        val fragmentDefinitions = fragments.mapValues { (_, info) ->
-            parser.parseDocument(info.document)
-                .definitions
-                .filterIsInstance<FragmentDefinition>()
-                .first()
-        }
+        val fragmentDefinitions =
+            fragments.mapValues { (_, info) ->
+                parser.parseDocument(info.document)
+                    .definitions
+                    .filterIsInstance<FragmentDefinition>()
+                    .first()
+            }
 
         return operations.map { operation ->
             val flattenedDocument = flattenFragments(operation.document, fragmentDefinitions)
@@ -75,48 +91,55 @@ class FragmentResolver {
         val relevantDefinitions = fragmentDefinitions.filterKeys { it in referencedNames }
 
         val transformer = AstTransformer()
-        val transformed = transformer.transform(document, object : NodeVisitorStub() {
-            @Suppress("UNCHECKED_CAST")
-            override fun visitFragmentSpread(
-                node: FragmentSpread,
-                context: TraverserContext<graphql.language.Node<*>>,
-            ): TraversalControl {
-                val definition = relevantDefinitions[node.name]
-                    ?: return TraversalControl.CONTINUE
+        val transformed =
+            transformer.transform(
+                document,
+                object : NodeVisitorStub() {
+                    @Suppress("UNCHECKED_CAST")
+                    override fun visitFragmentSpread(
+                        node: FragmentSpread,
+                        context: TraverserContext<graphql.language.Node<*>>,
+                    ): TraversalControl {
+                        val definition =
+                            relevantDefinitions[node.name]
+                                ?: return TraversalControl.CONTINUE
 
-                // Replace spread with an inline fragment that carries the definition's
-                // selection set and type condition. The AstTransformer will continue
-                // traversing into the children of this new node, resolving any nested
-                // FragmentSpread references automatically.
-                val inlineFragment = InlineFragment.newInlineFragment()
-                    .typeCondition(definition.typeCondition)
-                    .selectionSet(definition.selectionSet)
-                    .build()
+                        // Replace spread with an inline fragment that carries the definition's
+                        // selection set and type condition. The AstTransformer will continue
+                        // traversing into the children of this new node, resolving any nested
+                        // FragmentSpread references automatically.
+                        val inlineFragment =
+                            InlineFragment.newInlineFragment()
+                                .typeCondition(definition.typeCondition)
+                                .selectionSet(definition.selectionSet)
+                                .build()
 
-                return TreeTransformerUtil.changeNode(
-                    context as TraverserContext<InlineFragment>,
-                    inlineFragment,
-                )
-            }
-        })
+                        return TreeTransformerUtil.changeNode(
+                            context as TraverserContext<InlineFragment>,
+                            inlineFragment,
+                        )
+                    }
+                },
+            )
 
         // Re-print with deterministic formatting
         return AstPrinter.printAst(transformed)
     }
 
-    private fun collectReferencedNames(
-        document: graphql.language.Document,
-    ): Set<String> {
+    private fun collectReferencedNames(document: graphql.language.Document): Set<String> {
         val names = mutableSetOf<String>()
-        NodeTraverser().depthFirst(object : NodeVisitorStub() {
-            override fun visitFragmentSpread(
-                node: FragmentSpread,
-                context: TraverserContext<graphql.language.Node<*>>,
-            ): TraversalControl {
-                names.add(node.name)
-                return TraversalControl.CONTINUE
-            }
-        }, document)
+        NodeTraverser().depthFirst(
+            object : NodeVisitorStub() {
+                override fun visitFragmentSpread(
+                    node: FragmentSpread,
+                    context: TraverserContext<graphql.language.Node<*>>,
+                ): TraversalControl {
+                    names.add(node.name)
+                    return TraversalControl.CONTINUE
+                }
+            },
+            document,
+        )
         return names
     }
 
@@ -129,11 +152,12 @@ class FragmentResolver {
         fragmentDefinitions: Map<String, FragmentDefinition>,
     ) {
         for (name in fragmentNames) {
-            val definition = fragmentDefinitions[name]
-                ?: throw IllegalArgumentException(
-                    "Fragment '$name' is referenced but not defined. " +
-                        "Available fragments: ${fragmentDefinitions.keys}"
-                )
+            val definition =
+                fragmentDefinitions[name]
+                    ?: throw IllegalArgumentException(
+                        "Fragment '$name' is referenced but not defined. " +
+                            "Available fragments: ${fragmentDefinitions.keys}",
+                    )
         }
 
         val visited = mutableSetOf<String>()
@@ -142,7 +166,7 @@ class FragmentResolver {
         fun dfs(name: String) {
             if (name in inStack) {
                 throw IllegalArgumentException(
-                    "Cyclic fragment reference detected: $name"
+                    "Cyclic fragment reference detected: $name",
                 )
             }
             if (name in visited) return
@@ -152,15 +176,18 @@ class FragmentResolver {
             visited.add(name)
 
             // Find fragment references within this fragment definition
-            NodeTraverser().depthFirst(object : NodeVisitorStub() {
-                override fun visitFragmentSpread(
-                    node: FragmentSpread,
-                    context: TraverserContext<graphql.language.Node<*>>,
-                ): TraversalControl {
-                    dfs(node.name)
-                    return TraversalControl.CONTINUE
-                }
-            }, definition)
+            NodeTraverser().depthFirst(
+                object : NodeVisitorStub() {
+                    override fun visitFragmentSpread(
+                        node: FragmentSpread,
+                        context: TraverserContext<graphql.language.Node<*>>,
+                    ): TraversalControl {
+                        dfs(node.name)
+                        return TraversalControl.CONTINUE
+                    }
+                },
+                definition,
+            )
 
             inStack.remove(name)
         }

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -1,7 +1,11 @@
+import co.anitrend.retrofit.graphql.buildSrc.plugin.components.configureSpotlessForJvm
+
 plugins {
     kotlin("jvm")
     `java-gradle-plugin`
 }
+
+configureSpotlessForJvm()
 
 gradlePlugin {
     plugins {
@@ -18,3 +22,4 @@ dependencies {
     implementation(gradleApi())
     compileOnly(libs.android.gradle.plugin)
 }
+

--- a/gradle-plugin/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/GenerateGraphQLSourcesTask.kt
+++ b/gradle-plugin/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/GenerateGraphQLSourcesTask.kt
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 AniTrend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package co.anitrend.retrofit.graphql.codegen
 
 import co.anitrend.retrofit.graphql.codegen.generate.DocumentGenerator
@@ -40,7 +56,6 @@ import java.io.File
  * - Per-operation request helper objects
  */
 abstract class GenerateGraphQLSourcesTask : DefaultTask() {
-
     @get:Input
     abstract val packageName: Property<String>
 
@@ -92,7 +107,7 @@ abstract class GenerateGraphQLSourcesTask : DefaultTask() {
                 if (allFragments.containsKey(fragment.name)) {
                     throw IllegalArgumentException(
                         "Duplicate fragment definition '${fragment.name}' " +
-                            "found in ${file.name}. Fragment names must be unique."
+                            "found in ${file.name}. Fragment names must be unique.",
                     )
                 }
                 allFragments[fragment.name] = fragment
@@ -105,7 +120,7 @@ abstract class GenerateGraphQLSourcesTask : DefaultTask() {
         if (duplicates.isNotEmpty()) {
             throw IllegalArgumentException(
                 "Duplicate operation names found: ${duplicates.joinToString(", ")}. " +
-                    "Operation names must be unique across all .graphql files."
+                    "Operation names must be unique across all .graphql files.",
             )
         }
 
@@ -120,19 +135,22 @@ abstract class GenerateGraphQLSourcesTask : DefaultTask() {
             val schemaParser = SchemaParser()
             schemaTypes = schemaParser.parse(schemaFile.get().asFile)
             scalarMap = scalarMappings.orNull ?: emptyMap()
-            schemaTypeNames = schemaTypes.map { it.let { t ->
-                when (t) {
-                    is SchemaType.InputObject -> t.name
-                    is SchemaType.Enum -> t.name
-                    is SchemaType.Scalar -> t.name
-                }
-            } }.toSet()
+            schemaTypeNames =
+                schemaTypes.map {
+                    it.let { t ->
+                        when (t) {
+                            is SchemaType.InputObject -> t.name
+                            is SchemaType.Enum -> t.name
+                            is SchemaType.Scalar -> t.name
+                        }
+                    }
+                }.toSet()
         } else {
             if (generateVariables.get()) {
                 logger.warn(
                     "generateVariables is enabled but no schema file is set. " +
                         "Input object and enum generation will be skipped. " +
-                        "Variable classes will use scalar mappings only."
+                        "Variable classes will use scalar mappings only.",
                 )
             }
             schemaTypes = emptyList()
@@ -174,13 +192,18 @@ abstract class GenerateGraphQLSourcesTask : DefaultTask() {
         // Variable / input / enum / request helper generation
         if (generateVariables.get()) {
             generateVariableArtifacts(
-                resolvedOperations, schemaTypes, scalarMap, schemaTypeNames, pkg, outputDirectory
+                resolvedOperations,
+                schemaTypes,
+                scalarMap,
+                schemaTypeNames,
+                pkg,
+                outputDirectory,
             )
         }
 
         logger.lifecycle(
             "Generated GraphQL sources for ${resolvedOperations.size} operation(s) " +
-                "in package '$pkg'"
+                "in package '$pkg'",
         )
     }
 
@@ -197,9 +220,13 @@ abstract class GenerateGraphQLSourcesTask : DefaultTask() {
 
         // Generate per-operation variable classes
         operations.forEach { operation ->
-            val varFile = VariableClassGenerator.generate(
-                operation, pkg, scalarMap, schemaTypeNames
-            )
+            val varFile =
+                VariableClassGenerator.generate(
+                    operation,
+                    pkg,
+                    scalarMap,
+                    schemaTypeNames,
+                )
             if (varFile != null) {
                 writeFile(varFile, outputDirectory)
                 logger.info("Generated ${operation.name}Variables")
@@ -226,9 +253,13 @@ abstract class GenerateGraphQLSourcesTask : DefaultTask() {
 
         // Generate per-operation request helpers
         operations.forEach { operation ->
-            val reqFile = OperationRequestGenerator.generate(
-                operation, pkg, scalarMap, schemaTypeNames
-            )
+            val reqFile =
+                OperationRequestGenerator.generate(
+                    operation,
+                    pkg,
+                    scalarMap,
+                    schemaTypeNames,
+                )
             writeFile(reqFile, outputDirectory)
             logger.info("Generated ${operation.name} request helper")
         }
@@ -256,7 +287,7 @@ abstract class GenerateGraphQLSourcesTask : DefaultTask() {
                         "Unknown type '$typeName' in variable '${variable.name}' " +
                             "of operation '${operation.name}'. " +
                             "Add a scalar mapping in the retrofitGraphQL {} extension, e.g.:\n" +
-                            "  scalars { map(\"$typeName\", \"kotlin.String\") }"
+                            "  scalars { map(\"$typeName\", \"kotlin.String\") }",
                     )
                 }
             }
@@ -270,7 +301,10 @@ abstract class GenerateGraphQLSourcesTask : DefaultTask() {
         }
     }
 
-    private fun writeFile(fileSpec: com.squareup.kotlinpoet.FileSpec, outputDirectory: File) {
+    private fun writeFile(
+        fileSpec: com.squareup.kotlinpoet.FileSpec,
+        outputDirectory: File,
+    ) {
         fileSpec.writeTo(outputDirectory)
     }
 }

--- a/gradle-plugin/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/RetrofitGraphQLExtension.kt
+++ b/gradle-plugin/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/RetrofitGraphQLExtension.kt
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 AniTrend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package co.anitrend.retrofit.graphql.codegen
 
 import org.gradle.api.Action
@@ -24,7 +40,6 @@ import org.gradle.api.provider.Property
 // ```
 //
 abstract class GraphQLTargetExtension {
-
     //
     // The Kotlin package name for generated source files.
     // Defaults to "co.anitrend.graphql.generated".
@@ -101,7 +116,6 @@ abstract class GraphQLTargetExtension {
 // Each target can override these individually.
 //
 abstract class CommonExtension {
-
     //
     // Whether to generate GraphQLOperations constants. Default true.
     //
@@ -168,7 +182,6 @@ abstract class CommonExtension {
 // ```
 //
 open class RetrofitGraphQLExtension {
-
     //
     // Common settings shared across all targets.
     // Set by the plugin during apply.
@@ -199,7 +212,10 @@ open class RetrofitGraphQLExtension {
     //
     // Register a named code-generation target.
     //
-    fun target(name: String, action: Action<GraphQLTargetExtension>) {
+    fun target(
+        name: String,
+        action: Action<GraphQLTargetExtension>,
+    ) {
         action.execute(targets.maybeCreate(name))
     }
 
@@ -281,7 +297,10 @@ open class ScalarMappingExtension {
     // @param graphqlType The GraphQL scalar name (e.g. "DateTime").
     // @param kotlinType The fully-qualified Kotlin type (e.g. "kotlin.String").
     //
-    fun map(graphqlType: String, kotlinType: String) {
+    fun map(
+        graphqlType: String,
+        kotlinType: String,
+    ) {
         mappings[graphqlType] = kotlinType
     }
 

--- a/gradle-plugin/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/RetrofitGraphQLPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/RetrofitGraphQLPlugin.kt
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 AniTrend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package co.anitrend.retrofit.graphql.codegen
 
 import com.android.build.gradle.AppExtension
@@ -45,12 +61,12 @@ import org.gradle.api.tasks.TaskProvider
 // }
 // ```
 class RetrofitGraphQLPlugin : Plugin<Project> {
-
     override fun apply(project: Project) {
-        val extension = project.extensions.create(
-            "retrofitGraphQL",
-            RetrofitGraphQLExtension::class.java,
-        )
+        val extension =
+            project.extensions.create(
+                "retrofitGraphQL",
+                RetrofitGraphQLExtension::class.java,
+            )
 
         // Create common extension
         extension.common = project.objects.newInstance(CommonExtension::class.java)
@@ -65,15 +81,20 @@ class RetrofitGraphQLPlugin : Plugin<Project> {
                 // No targets configured at all -- create a default "main" task
                 val defaultTarget = extension.targets.maybeCreate("main")
                 createTargetTask(
-                    project, extension, "main", defaultTarget, "generateGraphQLSources",
+                    project,
+                    extension,
+                    "main",
+                    defaultTarget,
+                    "generateGraphQLSources",
                 )
             } else {
                 targetMap.forEach { (name, target) ->
-                    val taskName = if (name == "main") {
-                        "generateGraphQLSources"
-                    } else {
-                        "generateGraphQLSources${name.replaceFirstChar { it.uppercase() }}"
-                    }
+                    val taskName =
+                        if (name == "main") {
+                            "generateGraphQLSources"
+                        } else {
+                            "generateGraphQLSources${name.replaceFirstChar { it.uppercase() }}"
+                        }
                     createTargetTask(project, extension, name, target, taskName)
                 }
             }
@@ -87,10 +108,11 @@ class RetrofitGraphQLPlugin : Plugin<Project> {
         target: GraphQLTargetExtension,
         taskName: String,
     ) {
-        val taskProvider = project.tasks.register(
-            taskName,
-            GenerateGraphQLSourcesTask::class.java,
-        )
+        val taskProvider =
+            project.tasks.register(
+                taskName,
+                GenerateGraphQLSourcesTask::class.java,
+            )
 
         taskProvider.configure { task ->
             task.packageName.set(target.packageName)
@@ -99,11 +121,12 @@ class RetrofitGraphQLPlugin : Plugin<Project> {
 
             // Default output directory per target.
             // For the legacy "main" target, use the simpler path for backward compatibility.
-            val defaultOutputDir = if (targetName == "main") {
-                project.layout.buildDirectory.dir("generated/source/graphql")
-            } else {
-                project.layout.buildDirectory.dir("generated/source/graphql/$targetName")
-            }
+            val defaultOutputDir =
+                if (targetName == "main") {
+                    project.layout.buildDirectory.dir("generated/source/graphql")
+                } else {
+                    project.layout.buildDirectory.dir("generated/source/graphql/$targetName")
+                }
             task.outputDir.convention(defaultOutputDir)
             task.outputDir.set(target.outputDir)
 


### PR DESCRIPTION
Extract duplicated spotless configuration from annotations, codegen-core, and gradle-plugin into a shared `configureSpotlessForJvm()` helper in buildSrc.

**Changes:**
- New `buildSrc/.../JvmConfiguration.kt` — shared helper function
- Simplified 3 JVM build files (annotations, codegen-core, gradle-plugin)
- Removed root buildscript `classpath(libs.spotless.gradle)` (now via buildSrc)
- Applied ktlint formatting + Apache 2.0 license headers to all JVM sources

**Zero risk to Android modules** — CorePlugin and Android config files untouched.