### PR TITLE
fix(build): jitpack hardening and multi-module Dokka for JVM modules

### DIFF
--- a/.github/workflows/gradle-dokka.yml
+++ b/.github/workflows/gradle-dokka.yml
@@ -23,13 +23,25 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Generate docs with dokka
-        run: ./gradlew :library:dokkaGeneratePublicationHtml
-        # TODO: Switch to multi-module Dokka. Currently only publishes :library facade docs
-        # (type aliases pointing to co.anitrend.retrofit.graphql.* packages).
-        # Future: use dokkaHtmlMultiModule or a composite task to document all library-type modules.
+        run: |
+          ./gradlew :annotations:dokkaGeneratePublicationHtml \
+                    :api:dokkaGeneratePublicationHtml \
+                    :android-assets:dokkaGeneratePublicationHtml \
+                    :runtime:dokkaGeneratePublicationHtml \
+                    :codegen-core:dokkaGeneratePublicationHtml \
+                    :serialization-gson:dokkaGeneratePublicationHtml \
+                    :serialization-kotlinx:dokkaGeneratePublicationHtml \
+                    :library:dokkaGeneratePublicationHtml
+          # Merge all module docs into combined-docs
+          mkdir -p combined-docs
+          for module in annotations api android-assets runtime codegen-core serialization-gson serialization-kotlinx library; do
+            if [ -d "$module/build/dokka/html" ]; then
+              cp -r "$module/build/dokka/html/"* combined-docs/ 2>/dev/null || true
+            fi
+          done
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
           branch: docs # The branch the action should deploy to.
-          folder: library/build/dokka/html # The folder the action should deploy.
+          folder: combined-docs

--- a/annotations/build.gradle.kts
+++ b/annotations/build.gradle.kts
@@ -1,3 +1,4 @@
+import co.anitrend.retrofit.graphql.buildSrc.plugin.components.configureDokkaForJvm
 import co.anitrend.retrofit.graphql.buildSrc.plugin.components.configureSpotlessForJvm
 
 plugins {
@@ -5,4 +6,5 @@ plugins {
 }
 
 configureSpotlessForJvm()
+configureDokkaForJvm()
 

--- a/buildSrc/src/main/java/co/anitrend/retrofit/graphql/buildSrc/plugin/components/JvmConfiguration.kt
+++ b/buildSrc/src/main/java/co/anitrend/retrofit/graphql/buildSrc/plugin/components/JvmConfiguration.kt
@@ -4,6 +4,7 @@ import co.anitrend.retrofit.graphql.buildSrc.plugin.extensions.libs
 import com.diffplug.gradle.spotless.SpotlessExtension
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
+import org.jetbrains.dokka.gradle.DokkaExtension
 
 fun Project.configureSpotlessForJvm() {
     plugins.apply("com.diffplug.spotless")
@@ -18,6 +19,20 @@ fun Project.configureSpotlessForJvm() {
             ktlint(libs.pintrest.ktlint.get().version)
                 .editorConfigOverride(mapOf("ktlint_standard_filename" to "disabled"))
             licenseHeaderFile(rootProject.file("spotless/copyright.kt"))
+        }
+    }
+}
+
+fun Project.configureDokkaForJvm() {
+    plugins.apply("org.jetbrains.dokka")
+    extensions.configure<DokkaExtension> {
+        moduleName.set("retrofit-graphql-${this@configureDokkaForJvm.name}")
+        dokkaSourceSets.configureEach {
+            skipDeprecated.set(false)
+            reportUndocumented.set(true)
+            skipEmptyPackages.set(true)
+            jdkVersion.set(21)
+            sourceRoots.from(file("src"))
         }
     }
 }

--- a/codegen-core/build.gradle.kts
+++ b/codegen-core/build.gradle.kts
@@ -1,3 +1,4 @@
+import co.anitrend.retrofit.graphql.buildSrc.plugin.components.configureDokkaForJvm
 import co.anitrend.retrofit.graphql.buildSrc.plugin.components.configureSpotlessForJvm
 
 plugins {
@@ -5,6 +6,7 @@ plugins {
 }
 
 configureSpotlessForJvm()
+configureDokkaForJvm()
 
 dependencies {
     implementation(libs.graphql.java)

--- a/gradle-plugin/buildSrc/src/main/java/co/anitrend/retrofit/graphql/buildSrc/plugin/components/JvmConfiguration.kt
+++ b/gradle-plugin/buildSrc/src/main/java/co/anitrend/retrofit/graphql/buildSrc/plugin/components/JvmConfiguration.kt
@@ -27,3 +27,12 @@ fun Project.configureSpotlessForJvm() {
         }
     }
 }
+
+/**
+ * Stub for the composite build. Dokka is only needed in the root build
+ * where API docs are generated; this avoids adding a Dokka dependency
+ * to the composite build's buildSrc.
+ */
+fun Project.configureDokkaForJvm() {
+    // No-op: composite build does not generate Dokka for codegen-core
+}

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -3,8 +3,7 @@ jdk:
 #before_install:
 #   - ./custom_setup.sh
 install:
-  - echo "Running build commands"
-  - ./gradlew build --stacktrace
-  - ./gradlew publishMavenPublicationToMavenLocal
+  - ./gradlew build --stacktrace --no-daemon -x lint -x lintVitalRelease
+  - ./gradlew publishMavenPublicationToMavenLocal --no-daemon
 env:
   CI: "true"


### PR DESCRIPTION
## Summary

- **jitpack.yml:** Added `--no-daemon` and `-x lint -x lintVitalRelease` for Docker/CI reliability
- **Dokka for JVM modules:** `:annotations` and `:codegen-core` now generate API docs via `configureDokkaForJvm()` helper in buildSrc
- **Multi-module CI:** `gradle-dokka.yml` generates docs for all 8 modules and merges into `combined-docs/`
- **Composite build sync:** Added no-op `configureDokkaForJvm()` stub in composite build's buildSrc

Build verified: `./gradlew :app:compileDebugKotlin`, `:annotations:dokkaGeneratePublicationHtml`, `:codegen-core:dokkaGeneratePublicationHtml` all pass.