### PR TITLE
fix(dokka): proper multi-module Dokka using root-level aggregation

### DIFF
--- a/.github/workflows/gradle-dokka.yml
+++ b/.github/workflows/gradle-dokka.yml
@@ -9,6 +9,9 @@ env:
 
 jobs:
   gradle-dokka:
+    name: Generate Dokka Documentation
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -23,60 +26,10 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Generate docs with dokka
-        run: |
-          ./gradlew :annotations:dokkaGeneratePublicationHtml \
-                    :api:dokkaGeneratePublicationHtml \
-                    :android-assets:dokkaGeneratePublicationHtml \
-                    :runtime:dokkaGeneratePublicationHtml \
-                    :codegen-core:dokkaGeneratePublicationHtml \
-                    :serialization-gson:dokkaGeneratePublicationHtml \
-                    :serialization-kotlinx:dokkaGeneratePublicationHtml \
-                    :library:dokkaGeneratePublicationHtml
-          # Merge all module docs into combined-docs with subdirectories
-          mkdir -p combined-docs
-          for module in annotations api android-assets runtime codegen-core serialization-gson serialization-kotlinx library; do
-            if [ -d "$module/build/dokka/html" ]; then
-              mkdir -p "combined-docs/$module"
-              cp -r "$module/build/dokka/html/"* "combined-docs/$module/" 2>/dev/null || true
-            fi
-          done
-          # Generate a root index.html linking to each module's docs
-          cat > combined-docs/index.html << 'HTML'
-          <!DOCTYPE html>
-          <html lang="en">
-          <head>
-          <meta charset="UTF-8">
-          <meta name="viewport" content="width=device-width, initial-scale=1.0">
-          <title>retrofit-graphql API Docs</title>
-          <style>
-            body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 720px; margin: 40px auto; padding: 0 20px; line-height: 1.6; }
-            h1 { border-bottom: 2px solid #eee; padding-bottom: 12px; }
-            ul { list-style: none; padding: 0; }
-            li { margin: 8px 0; }
-            a { color: #0366d6; text-decoration: none; font-size: 16px; }
-            a:hover { text-decoration: underline; }
-            code { background: #f6f8fa; padding: 2px 6px; border-radius: 3px; font-size: 14px; }
-          </style>
-          </head>
-          <body>
-          <h1>retrofit-graphql API Documentation</h1>
-          <p>Multi-module Kotlin library for injecting <code>.graphql</code> files into Retrofit HTTP requests.</p>
-          <ul>
-          <li><a href="annotations/">annotations</a> <span style="color:#666">&mdash; @GraphQuery annotation</span></li>
-          <li><a href="api/">api</a> <span style="color:#666">&mdash; Public API interfaces and models</span></li>
-          <li><a href="android-assets/">android-assets</a> <span style="color:#666">&mdash; Asset-based query discovery</span></li>
-          <li><a href="runtime/">runtime</a> <span style="color:#666">&mdash; Retrofit Converter.Factory</span></li>
-          <li><a href="codegen-core/">codegen-core</a> <span style="color:#666">&mdash; Code generation engine</span></li>
-          <li><a href="serialization-gson/">serialization-gson</a> <span style="color:#666">&mdash; Gson backend</span></li>
-          <li><a href="serialization-kotlinx/">serialization-kotlinx</a> <span style="color:#666">&mdash; kotlinx.serialization backend</span></li>
-          <li><a href="library/">library</a> <span style="color:#666">&mdash; Legacy facade (deprecated type aliases)</span></li>
-          </ul>
-          </body>
-          </html>
-          HTML
+        run: ./gradlew dokkaGeneratePublicationHtml
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
           branch: docs # The branch the action should deploy to.
-          folder: combined-docs
+          folder: dokka-docs

--- a/.gitignore
+++ b/.gitignore
@@ -251,3 +251,4 @@ app/lint-baseline.xml
 
 # OpenCode deepwork session files
 .slim/deepwork/
+dokka-docs/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,9 @@
+import org.jetbrains.dokka.gradle.DokkaExtension
+
+plugins {
+    id("org.jetbrains.dokka")
+}
+
 buildscript {
     repositories {
         google()
@@ -15,5 +21,44 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+    }
+}
+
+// Multi-module Dokka: aggregate docs from all subprojects
+dependencies {
+    dokka(project(":annotations"))
+    dokka(project(":api"))
+    dokka(project(":android-assets"))
+    dokka(project(":runtime"))
+    dokka(project(":codegen-core"))
+    dokka(project(":serialization-gson"))
+    dokka(project(":serialization-kotlinx"))
+    dokka(project(":library"))
+}
+
+dokka {
+    dokkaPublications.html {
+        outputDirectory.set(rootProject.file("dokka-docs"))
+        failOnWarning.set(false)
+    }
+}
+
+// Configure source links for subprojects that have Dokka applied
+subprojects {
+    plugins.withId("org.jetbrains.dokka") {
+        extensions.configure(DokkaExtension::class.java) {
+            val modulePath = project.path.removePrefix(":").replace(":", "/")
+
+            dokkaSourceSets.configureEach {
+                reportUndocumented.set(true)
+                skipEmptyPackages.set(true)
+
+                sourceLink {
+                    localDirectory.set(layout.projectDirectory.dir("src/main/kotlin"))
+                    remoteUrl.set(java.net.URI("https://github.com/AniTrend/retrofit-graphql/tree/develop/$modulePath/src/main/kotlin"))
+                    remoteLineSuffix.set("#L")
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Replaces the per-module-task + hand-rolled-index.html approach with proper Dokka V2 multi-module aggregation as used in `support-query-builder`.

**What changed:**
- Root `build.gradle.kts`: `id("org.jetbrains.dokka")` without version (resolved from buildSrc classpath)
- `dokka()` dependencies aggregate all 8 subprojects into single output at `dokka-docs/`
- Dokka natively produces per-module subdirectories — no manual index.html
- CI simplified to single `./gradlew dokkaGeneratePublicationHtml`
- Added `permissions: contents: write` for deploy action

**Verified:**
- `./gradlew dokkaGeneratePublicationHtml` → BUILD SUCCESSFUL
- Output at `dokka-docs/` with 10 subdirectories (8 modules + images + scripts)
- `./gradlew :app:compileDebugKotlin` → BUILD SUCCESSFUL