### PR TITLE
fix(codegen): iteratively inline nested fragment spreads

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -12,6 +12,17 @@
                   <project path="$PROJECT_DIR$/buildSrc" />
                 </projects>
               </build>
+              <build path="$PROJECT_DIR$/gradle-plugin" name="gradle-plugin">
+                <projects>
+                  <project path="$PROJECT_DIR$/codegen-core" />
+                  <project path="$PROJECT_DIR$/gradle-plugin" />
+                </projects>
+              </build>
+              <build path="$PROJECT_DIR$/gradle-plugin/buildSrc" name="buildSrc">
+                <projects>
+                  <project path="$PROJECT_DIR$/gradle-plugin/buildSrc" />
+                </projects>
+              </build>
             </builds>
           </compositeBuild>
         </compositeConfiguration>
@@ -21,9 +32,18 @@
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
+            <option value="$PROJECT_DIR$/android-assets" />
+            <option value="$PROJECT_DIR$/annotations" />
+            <option value="$PROJECT_DIR$/api" />
             <option value="$PROJECT_DIR$/app" />
             <option value="$PROJECT_DIR$/buildSrc" />
+            <option value="$PROJECT_DIR$/codegen-core" />
+            <option value="$PROJECT_DIR$/gradle-plugin" />
+            <option value="$PROJECT_DIR$/gradle-plugin/buildSrc" />
             <option value="$PROJECT_DIR$/library" />
+            <option value="$PROJECT_DIR$/runtime" />
+            <option value="$PROJECT_DIR$/serialization-gson" />
+            <option value="$PROJECT_DIR$/serialization-kotlinx" />
           </set>
         </option>
       </GradleProjectSettings>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.21" />
+    <option name="externalSystemId" value="Gradle" />
+    <option name="version" value="2.4.0" />
   </component>
 </project>

--- a/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/resolve/FragmentResolver.kt
+++ b/codegen-core/src/main/kotlin/co/anitrend/retrofit/graphql/codegen/resolve/FragmentResolver.kt
@@ -88,79 +88,73 @@ class FragmentResolver {
      * 2. Compute all transitively-reachable fragment names from the operation's
      *    direct fragment spreads, validating that every referenced fragment exists.
      * 3. Detect cycles among the reachable fragments.
-     * 4. Transform: replace each [FragmentSpread] with an inline fragment.
-     * 5. Validate: no named fragment spreads remain (defensive invariant check).
+     * 4. Iteratively transform: replace each [FragmentSpread] with an inline
+     *    fragment.  Because the [AstTransformer] does not recursively visit the
+     *    **children** of nodes inserted via [TreeTransformerUtil.changeNode], a
+     *    single pass leaves nested fragment spreads unresolved.  We therefore
+     *    loop: after each pass we check whether any fragment spreads remain and,
+     *    if so, re-transform the result.  The loop exits when the invariant check
+     *    passes.
+     * 5. Serialize the fully-resolved AST back to a GraphQL document string.
      */
     private fun flattenFragments(
         documentText: String,
         fragmentDefinitions: Map<String, FragmentDefinition>,
     ): String {
-        val document = parser.parseDocument(documentText)
-
         // Phase 1: Compute full transitive closure of reachable fragment names
-        val reachableNames = computeReachableFragments(document, fragmentDefinitions)
+        val firstDocument = parser.parseDocument(documentText)
+        val reachableNames = computeReachableFragments(firstDocument, fragmentDefinitions)
         if (reachableNames.isEmpty()) return documentText
 
         // Phase 2: Validate no cycles among reachable fragments
         detectCycles(reachableNames, fragmentDefinitions)
 
-        // Phase 3: Inline fragments using AstTransformer
         val relevantDefinitions = fragmentDefinitions.filterKeys { it in reachableNames }
 
+        // Phase 3-4: Iteratively inline fragments until no spreads remain.
+        // The AstTransformer does not recursively visit children of nodes
+        // inserted via changeNode, so nested spreads (e.g. ...MediaTitleFragment
+        // inside ...MediaCoreFragment) require multiple passes.
         val transformer = AstTransformer()
-        val transformed =
-            transformer.transform(
-                document,
-                object : NodeVisitorStub() {
-                    @Suppress("UNCHECKED_CAST")
-                    override fun visitFragmentSpread(
-                        node: FragmentSpread,
-                        context: TraverserContext<graphql.language.Node<*>>,
-                    ): TraversalControl {
-                        val definition =
-                            relevantDefinitions[node.name]
-                                ?: return TraversalControl.CONTINUE
+        val spreadVisitor =
+            object : NodeVisitorStub() {
+                @Suppress("UNCHECKED_CAST")
+                override fun visitFragmentSpread(
+                    node: FragmentSpread,
+                    context: TraverserContext<graphql.language.Node<*>>,
+                ): TraversalControl {
+                    val definition =
+                        relevantDefinitions[node.name]
+                            ?: return TraversalControl.CONTINUE
 
-                        // Replace spread with an inline fragment that carries the definition's
-                        // selection set and type condition, plus any directives (e.g. @include,
-                        // @skip) from the original spread. The AstTransformer will continue
-                        // traversing into the children of this new node, resolving any nested
-                        // FragmentSpread references automatically.
-                        val spreadDirectives: List<Directive> = node.directives
-                        val inlineFragment =
-                            InlineFragment.newInlineFragment()
-                                .typeCondition(definition.typeCondition)
-                                .selectionSet(definition.selectionSet)
-                                .also { builder ->
-                                    if (spreadDirectives.isNotEmpty()) {
-                                        builder.directives(spreadDirectives)
-                                    }
+                    val spreadDirectives: List<Directive> = node.directives
+                    val inlineFragment =
+                        InlineFragment.newInlineFragment()
+                            .typeCondition(definition.typeCondition)
+                            .selectionSet(definition.selectionSet)
+                            .also { builder ->
+                                if (spreadDirectives.isNotEmpty()) {
+                                    builder.directives(spreadDirectives)
                                 }
-                                .build()
+                            }
+                            .build()
 
-                        return TreeTransformerUtil.changeNode(
-                            context as TraverserContext<InlineFragment>,
-                            inlineFragment,
-                        )
-                    }
-                },
-            )
+                    return TreeTransformerUtil.changeNode(
+                        context as TraverserContext<InlineFragment>,
+                        inlineFragment,
+                    )
+                }
+            }
 
-        // Phase 4: Defensive invariant check — no named fragment spreads should
-        // remain after inlining. This catches bugs where a fragment spread name
-        // was not found in relevantDefinitions (e.g. missing from transitive closure).
-        val remainingSpreads = collectSpreadNames(transformed)
-        if (remainingSpreads.isNotEmpty()) {
-            throw IllegalStateException(
-                "Incomplete fragment resolution: the following fragment spread(s) remain " +
-                    "unresolved after inlining: ${remainingSpreads.joinToString(", ")}. " +
-                    "Ensure all referenced fragment definitions are included in the " +
-                    "fragment definitions map.",
-            )
-        }
+        var document = firstDocument
+        var remainingSpreads: Set<String>
+        do {
+            document = transformer.transform(document, spreadVisitor) as graphql.language.Document
+            remainingSpreads = collectSpreadNames(document)
+        } while (remainingSpreads.isNotEmpty())
 
         // Serialize the transformed AST back to a GraphQL document string
-        return AstPrinter.printAst(transformed)
+        return AstPrinter.printAst(document)
     }
 
     /**


### PR DESCRIPTION
## Description

Follow-up to #424. The original recursive fragment resolution fix assumed that `AstTransformer` recursively visits the children of nodes inserted via `TreeTransformerUtil.changeNode`. In practice it does not, so a single transformation pass leaves nested fragment spreads (e.g. `...MediaTitleFragment` inside `...MediaCoreFragment`) unresolved in the generated document, producing invalid GraphQL requests.

### Root Cause

`flattenFragments()` performed a single `transformer.transform(document, spreadVisitor)` pass and then asserted no `FragmentSpread` nodes remained. Because `AstTransformer` does not descend into children of replacement nodes, any fragment spread nested inside an inlined fragment definition was left as an unresolved named spread.

### Fix

Replace the single-pass approach with an **iterative loop**:

1. Parse the document and compute the transitive closure of reachable fragments (unchanged).
2. Detect cycles among reachable fragments (unchanged).
3. Repeatedly transform the document with the same `spreadVisitor` until `collectSpreadNames` returns an empty set.
4. Serialize the fully-resolved AST.

The defensive invariant check is now the loop exit condition rather than a post-hoc assertion that could throw on deeply nested fragments.

### Additional changes

- `chore(ide)`: update IDE Gradle project settings to include all composite-build and subproject modules, and update the Kotlin compiler version from 2.0.21 to 2.4.0 to match the project toolchain.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (Improve existing functionality)